### PR TITLE
feat: improve 5 lowest-scoring skills + add Tessl review action

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/00-meta-initialization/new-project/SKILL.md
+++ b/00-meta-initialization/new-project/SKILL.md
@@ -1,15 +1,18 @@
 ---
-name: "new-project"
-description: "Use when the task matches skill: new project scaffold and this skill's local workflow."
+name: new-project
+description: "Use when starting a new software project to scaffold the full directory structure, context files, and documentation status tracker. Runs a 4-question interview to determine project name, vision, methodology (Waterfall/Agile/Hybrid), and owner, then auto-deduces domain and injects defaults. Follows the PRIME methodology."
+user-invocable: true
+triggers:
+  - start a new project
+  - create a new project
+  - scaffold a project
+  - new client project
+  - initialize project
 metadata:
-  use_when: "Use when the task matches skill: new project scaffold and this skill's local workflow."
-  do_not_use_when: "Do not use when a more specific upstream or downstream skill owns the task, or when the required project context has not been prepared."
-  required_inputs: "Provide the target project or document, the relevant context files, scope constraints, and any domain or standards inputs referenced here."
-  workflow: "Follow the ordered steps, review gates, and local generation logic in this file before consulting deeper support files as needed."
-  quality_standards: "Keep outputs grounded in source context, traceable to stated standards, and specific enough to review or verify."
-  anti_patterns: "Do not fabricate missing requirements, skip human review gates, or substitute vague prose for verifiable documentation."
-  outputs: "Produce or update the document, scaffold, analysis, or phase artifact that this skill defines."
-  references: "Use sibling files in this directory when deeper detail is needed."
+  portable: true
+  compatible_with:
+  - claude-code
+  - codex
 ---
 
 # Skill: New Project Scaffold

--- a/skills/language-standards/SKILL.md
+++ b/skills/language-standards/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: language-standards
-description: Language and tone standards for all written content across 3 languages
-  — English (British, East African), French (Francophone African), and Kiswahili (East
-  African standard). Enforces authentic, culturally appropriate, professional communication...
+description: "Use when writing or reviewing user-facing content in English (British, East African), French (Francophone African), or Kiswahili (East African standard). Enforces culturally authentic, professionally courteous tone and correct grammar across all three languages. Covers spelling conventions, date/number formats, CTAs, courteous phrasing, and country-specific tone adjustments."
+user-invocable: true
+triggers:
+  - language standards
+  - tone review
+  - multilingual copy
+  - British English style
+  - East African English
+  - French copy review
+  - Kiswahili content
+  - content localization
 metadata:
   portable: true
   compatible_with:
@@ -11,46 +19,57 @@ metadata:
 ---
 
 # Language Standards — Multi-Language Tone & Grammar
+
 Acknowledgement: Shared by Peter Bamuhigire, techguypeter.com, +256 784 464178.
 
 <!-- dual-compat-start -->
 ## Use When
 
-- Language and tone standards for all written content across 3 languages — English (British, East African), French (Francophone African), and Kiswahili (East African standard). Enforces authentic, culturally appropriate, professional communication...
-- The task needs reusable judgment, domain constraints, or a proven workflow rather than ad hoc advice.
+- Writing or reviewing website copy, headings, CTAs, descriptions, or microcopy in English, French, or Kiswahili
+- Auditing existing content for tone consistency and cultural appropriateness across supported languages
+- Localising content for East African or Francophone African markets
+- Ensuring British English spelling and formal East African professional tone in all English content
 
 ## Do Not Use When
 
-- The task is unrelated to `language-standards` or would be better handled by a more specific companion skill.
-- The request only needs a trivial answer and none of this skill's constraints or references materially help.
+- Writing purely internal technical documentation not seen by end users
+- The content is in a language not covered here (English, French, Kiswahili only)
+- Writing marketing copy that intentionally departs from formal tone (confirm with stakeholders first)
 
 ## Required Inputs
 
-- Gather relevant project context, constraints, and the concrete problem to solve; load `references` only as needed.
-- Confirm the desired deliverable: design, code, review, migration plan, audit, or documentation.
+- Target language(s) for the content
+- Content type (website copy, CTA buttons, notifications, email, documentation)
+- Target audience context (country, formality level, domain)
 
 ## Workflow
 
-- Read this `SKILL.md` first, then load only the referenced deep-dive files that are necessary for the task.
-- Apply the ordered guidance, checklists, and decision rules in this skill instead of cherry-picking isolated snippets.
-- Produce the deliverable with assumptions, risks, and follow-up work made explicit when they matter.
+1. Read this `SKILL.md` for core principles and English standards
+2. Load `references/skill-deep-dive.md` for detailed rules on spelling, dates, country-specific tone, French, and Kiswahili
+3. Apply the six core principles (clear, formal, no hype, professionally indirect, measured confidence, culturally authentic)
+4. Review all content against the language-specific rules for the target language
+5. Verify consistent verb tense within each section and consistent terminology across pages
 
 ## Quality Standards
 
-- Keep outputs execution-oriented, concise, and aligned with the repository's baseline engineering standards.
-- Preserve compatibility with existing project conventions unless the skill explicitly requires a stronger standard.
-- Prefer deterministic, reviewable steps over vague advice or tool-specific magic.
+- British English spelling throughout (colour, organisation, licence as noun)
+- Simple present or past tense preferred over progressive forms
+- Consistent verb tense within each section — no mixing past and present
+- Courteous, formally indirect phrasing that respects East African communication norms
+- No slang, exaggeration, or excessive marketing language
 
 ## Anti-Patterns
 
-- Treating examples as copy-paste truth without checking fit, constraints, or failure modes.
-- Loading every reference file by default instead of using progressive disclosure.
+- Using American English spelling in a British English context
+- Switching between formal and informal tone within the same page
+- Direct imperative commands without courteous softening
+- Machine-translating English copy into French or Kiswahili without cultural adaptation
+- Ignoring country-specific tone differences (Uganda vs Kenya vs Tanzania)
 
 ## Outputs
 
-- A concrete result that fits the task: implementation guidance, review findings, architecture decisions, templates, or generated artifacts.
-- Clear assumptions, tradeoffs, or unresolved gaps when the task cannot be completed from available context alone.
-- References used, companion skills, or follow-up actions when they materially improve execution.
+- Reviewed or written content that meets the language standards for the target language
+- Multilingual copy audit documenting tone, style, and grammar findings per page
 
 ## Evidence Produced
 

--- a/skills/software-business-models/SKILL.md
+++ b/skills/software-business-models/SKILL.md
@@ -1,8 +1,16 @@
 ---
 name: software-business-models
-description: Business model frameworks for software companies. Covers products vs
-  services vs hybrid models, platform business models, subscription vs perpetual licensing,
-  open source strategies, the services-to-product transition, and startup survival...
+description: "Use when choosing, evaluating, or transitioning between software business models — products vs services vs hybrid, platform mechanics, subscription vs perpetual licensing, open-source strategies, and the services-to-product transition. Applies Cusumano's frameworks for revenue model design, startup survival patterns, and go-to-market alignment."
+user-invocable: true
+triggers:
+  - choose business model
+  - product vs service
+  - SaaS business model
+  - services to product transition
+  - open source strategy
+  - platform business model
+  - software licensing model
+  - startup revenue model
 metadata:
   portable: true
   compatible_with:
@@ -11,46 +19,61 @@ metadata:
 ---
 
 # Software Business Models
+
 Acknowledgement: Shared by Peter Bamuhigire, techguypeter.com, +256 784 464178.
 
 <!-- dual-compat-start -->
 ## Use When
 
-- Business model frameworks for software companies. Covers products vs services vs hybrid models, platform business models, subscription vs perpetual licensing, open source strategies, the services-to-product transition, and startup survival...
-- The task needs reusable judgment, domain constraints, or a proven workflow rather than ad hoc advice.
+- Choosing a business model for a new software product or company
+- Evaluating whether to pivot from services to products (or vice versa)
+- Designing a revenue strategy that balances recurring income and services income
+- Deciding whether to open-source part of the technology stack
+- Advising on platform business model mechanics (two-sided markets, cold start)
+- Comparing subscription vs perpetual licensing for an enterprise product
 
 ## Do Not Use When
 
-- The task is unrelated to `software-business-models` or would be better handled by a more specific companion skill.
-- The request only needs a trivial answer and none of this skill's constraints or references materially help.
+- Setting specific price points or pricing tiers — use `software-pricing-strategy` instead
+- Tracking SaaS metrics (MRR, churn, LTV) — use `saas-business-metrics` instead
+- Designing the technical multi-tenant architecture — use `multi-tenant-saas-architecture` instead
 
 ## Required Inputs
 
-- Gather relevant project context, constraints, and the concrete problem to solve.
-- Confirm the desired deliverable: design, code, review, migration plan, audit, or documentation.
+- Current business context: services-only, product-only, or hybrid
+- Target market size and customer profile (enterprise, SMB, consumer)
+- Capital constraints and revenue timeline expectations
+- Competitive landscape and defensibility factors
 
 ## Workflow
 
-- Read this `SKILL.md` first, then load only the referenced deep-dive files that are necessary for the task.
-- Apply the ordered guidance, checklists, and decision rules in this skill instead of cherry-picking isolated snippets.
-- Produce the deliverable with assumptions, risks, and follow-up work made explicit when they matter.
+1. Read this `SKILL.md` for the business model frameworks and decision tree
+2. Classify the current and target business model using the three-model spectrum (section 1)
+3. If transitioning, apply the services-to-product framework (section 2)
+4. Evaluate platform mechanics if applicable (section 3)
+5. Select licensing model (section 4) and open-source strategy if relevant (section 5)
+6. Validate against startup survival patterns (section 6)
+7. Document the decision as an ADR with key assumptions and risks
 
 ## Quality Standards
 
-- Keep outputs execution-oriented, concise, and aligned with the repository's baseline engineering standards.
-- Preserve compatibility with existing project conventions unless the skill explicitly requires a stronger standard.
-- Prefer deterministic, reviewable steps over vague advice or tool-specific magic.
+- Ground recommendations in the specific market context, not generic advice
+- Quantify gross margin expectations for each model option considered
+- Address the cash flow timing gap between services and product revenue explicitly
+- Validate unit economics at realistic scale (100 customers, not 10,000)
 
 ## Anti-Patterns
 
-- Treating examples as copy-paste truth without checking fit, constraints, or failure modes.
-- Loading every reference file by default instead of using progressive disclosure.
+- Choosing products over services purely for valuation multiples without validating market fit
+- Delaying the product transition indefinitely because services cover payroll
+- Open-sourcing before product/market fit is established
+- Building a platform before solving the cold-start problem on at least one side
 
 ## Outputs
 
-- A concrete result that fits the task: implementation guidance, review findings, architecture decisions, templates, or generated artifacts.
-- Clear assumptions, tradeoffs, or unresolved gaps when the task cannot be completed from available context alone.
-- References used, companion skills, or follow-up actions when they materially improve execution.
+- Business model decision record (ADR format) with chosen model and key assumptions
+- Revenue model comparison with gross margin projections per option
+- Transition plan with quarterly milestones if changing models
 
 ## Evidence Produced
 

--- a/skills/update-claude-documentation/SKILL.md
+++ b/skills/update-claude-documentation/SKILL.md
@@ -1,8 +1,14 @@
 ---
-name: update-claude-documentation
-description: Update project documentation files (README.md, PROJECT_BRIEF.md, TECH_STACK.md,
-  ARCHITECTURE.md, docs/API.md, docs/DATABASE.md, CLAUDE.md, docs/plans/NEXT_FEATURES.md)
-  when significant changes occur. MANDATORY at end of each work session to...
+name: update-project-documentation
+description: "Use when you need to systematically update project documentation (README.md, PROJECT_BRIEF.md, TECH_STACK.md, ARCHITECTURE.md, docs/API.md, docs/DATABASE.md, CLAUDE.md, docs/plans/NEXT_FEATURES.md) after code changes, at end-of-session, or when closing for the day. Ensures all docs tell one cohesive story across audiences."
+user-invocable: true
+triggers:
+  - update project documentation
+  - update docs
+  - close for the day
+  - end of session docs
+  - sync documentation
+  - refresh project docs
 metadata:
   portable: true
   compatible_with:
@@ -10,57 +16,64 @@ metadata:
   - codex
 ---
 
-## Platform Notes
-
-- Optional helper plugins may help in some environments, but they must not be treated as required for this skill.
-
 # Update Claude Documentation
+
 Acknowledgement: Shared by Peter Bamuhigire, techguypeter.com, +256 784 464178.
 
 <!-- dual-compat-start -->
 ## Use When
 
-- Update project documentation files (README.md, PROJECT_BRIEF.md, TECH_STACK.md, ARCHITECTURE.md, docs/API.md, docs/DATABASE.md, CLAUDE.md, docs/plans/NEXT_FEATURES.md) when significant changes occur. MANDATORY at end of each work session to...
-- The task needs reusable judgment, domain constraints, or a proven workflow rather than ad hoc advice.
+- Updating project documentation (README.md, PROJECT_BRIEF.md, TECH_STACK.md, ARCHITECTURE.md, docs/API.md, docs/DATABASE.md, CLAUDE.md, docs/plans/NEXT_FEATURES.md) after significant code or architecture changes
+- Closing a work session and need to preserve context for the next session
+- Adding, removing, or modifying features that affect multiple documentation files
+- Restructuring project directories or changing development workflows
 
 ## Do Not Use When
 
-- The task is unrelated to `update-claude-documentation` or would be better handled by a more specific companion skill.
-- The request only needs a trivial answer and none of this skill's constraints or references materially help.
+- Making typo-only fixes (edit the file directly)
+- Updating code comments (not documentation scope)
+- Working on WIP features not yet merged to the main branch
 
 ## Required Inputs
 
-- Gather relevant project context, constraints, and the concrete problem to solve; load `references` only as needed.
-- Confirm the desired deliverable: design, code, review, migration plan, audit, or documentation.
+- The type of change made (feature, architecture, tech stack, API, database)
+- Which files or modules were affected
+- Whether the change is breaking or non-breaking
 
 ## Workflow
 
-- Read this `SKILL.md` first, then load only the referenced deep-dive files that are necessary for the task.
-- Apply the ordered guidance, checklists, and decision rules in this skill instead of cherry-picking isolated snippets.
-- Produce the deliverable with assumptions, risks, and follow-up work made explicit when they matter.
+1. Read this `SKILL.md`, then load only the `references/` files relevant to the current change type
+2. Identify all affected documentation files using the Change-to-File mapping below
+3. Read current state of all affected files before editing
+4. Update files in specific-to-general order: technical specs first, then architecture, then user-facing docs
+5. Verify cross-file consistency (terminology, versions, paths, component names)
+6. Update `docs/plans/NEXT_FEATURES.md` — mandatory at every session end
 
 ## Quality Standards
 
-- Keep outputs execution-oriented, concise, and aligned with the repository's baseline engineering standards.
-- Preserve compatibility with existing project conventions unless the skill explicitly requires a stronger standard.
-- Prefer deterministic, reviewable steps over vague advice or tool-specific magic.
+- All markdown files must stay under the 500-line hard limit
+- CLAUDE.md must stay under 10k characters as a navigation hub, not a content dump
+- Keep outputs execution-oriented and concise
+- Prefer deterministic, reviewable steps over vague advice
 
 ## Anti-Patterns
 
-- Treating examples as copy-paste truth without checking fit, constraints, or failure modes.
-- Loading every reference file by default instead of using progressive disclosure.
+- Updating only one file when multiple files reference the same concept
+- Using inconsistent terminology across files (pick one term and use it everywhere)
+- Bloating CLAUDE.md with detailed guides that belong in `docs/` subdirectories
+- Updating general docs before specific docs (always go specific-to-general)
 
 ## Outputs
 
-- A concrete result that fits the task: implementation guidance, review findings, architecture decisions, templates, or generated artifacts.
-- Clear assumptions, tradeoffs, or unresolved gaps when the task cannot be completed from available context alone.
-- References used, companion skills, or follow-up actions when they materially improve execution.
+- Updated documentation files that reflect the current state of the codebase
+- End-of-session completion document at `docs/plans/YYYY-MM-DD-[feature-name]-completion.md`
+- Updated `docs/plans/NEXT_FEATURES.md` with completed work and revised priorities
 
 ## Evidence Produced
 
 | Category | Artifact | Format | Example |
 |----------|----------|--------|---------|
-| Release evidence | Documentation update record | Markdown doc tracking changes made to README.md, PROJECT_BRIEF.md, TECH_STACK.md, ARCHITECTURE.md, docs/API.md, and docs/DATABASE.md | `docs/updates/doc-update-2026-04-16.md` |
+| Release evidence | Documentation update record | Markdown doc tracking changes made across all affected documentation files | `docs/updates/doc-update-2026-04-16.md` |
 
 ## References
 

--- a/skills/ux-for-ai/SKILL.md
+++ b/skills/ux-for-ai/SKILL.md
@@ -1,8 +1,15 @@
 ---
 name: ux-for-ai
-description: AI interface design framework for building AI-powered features that feel
-  premium, trustworthy, and world-class — not sloppy or robotic. Covers trust/transparency
-  principles, avoiding AI slop, human oversight requirements, onboarding AI features...
+description: "Use when designing or reviewing AI-powered features (chatbots, copilots, search, recommendations, generative outputs) to ensure they feel premium, trustworthy, and world-class. Applies the RETCH trust framework, progressive disclosure for AI capabilities, human oversight requirements, and graceful error degradation patterns. Based on Nudelman (2024)."
+user-invocable: true
+triggers:
+  - design AI feature
+  - AI UX review
+  - chatbot UX
+  - copilot design
+  - AI trust patterns
+  - AI onboarding
+  - review AI interface
 metadata:
   portable: true
   compatible_with:
@@ -11,46 +18,58 @@ metadata:
 ---
 
 # UX for AI — Design Framework
+
 Acknowledgement: Shared by Peter Bamuhigire, techguypeter.com, +256 784 464178.
 
 <!-- dual-compat-start -->
 ## Use When
 
-- AI interface design framework for building AI-powered features that feel premium, trustworthy, and world-class — not sloppy or robotic. Covers trust/transparency principles, avoiding AI slop, human oversight requirements, onboarding AI features...
-- The task needs reusable judgment, domain constraints, or a proven workflow rather than ad hoc advice.
+- Building any AI-powered feature, chatbot, copilot, or AI search interface
+- Designing AI recommendations, anomaly detection, or generative output surfaces
+- Reviewing existing AI features for trust, transparency, and premium feel
+- Onboarding users to AI capabilities without overwhelming them
+- Avoiding the "AI slop" feeling in AI-assisted products
 
 ## Do Not Use When
 
-- The task is unrelated to `ux-for-ai` or would be better handled by a more specific companion skill.
-- The request only needs a trivial answer and none of this skill's constraints or references materially help.
+- The feature has no AI component — use general UX skills instead
+- Building backend AI infrastructure with no user-facing surface
+- The task is purely about ML model accuracy or training, not user experience
 
 ## Required Inputs
 
-- Gather relevant project context, constraints, and the concrete problem to solve.
-- Confirm the desired deliverable: design, code, review, migration plan, audit, or documentation.
+- The AI feature type (chatbot, copilot, search, recommendations, generative)
+- Target user context (domain expertise level, risk tolerance, task complexity)
+- Whether this is new feature design or an audit of existing AI UX
 
 ## Workflow
 
-- Read this `SKILL.md` first, then load only the referenced deep-dive files that are necessary for the task.
-- Apply the ordered guidance, checklists, and decision rules in this skill instead of cherry-picking isolated snippets.
-- Produce the deliverable with assumptions, risks, and follow-up work made explicit when they matter.
+1. Read this `SKILL.md` for core principles and patterns
+2. Identify which RETCH principles (Restate, Calibrate, Explain, Transparent, Human oversight) apply
+3. Apply the relevant design patterns from sections 2-7 below
+4. Validate against the anti-patterns checklist in section 8
+5. Produce the deliverable with explicit assumptions about AI accuracy and failure modes
 
 ## Quality Standards
 
-- Keep outputs execution-oriented, concise, and aligned with the repository's baseline engineering standards.
-- Preserve compatibility with existing project conventions unless the skill explicitly requires a stronger standard.
-- Prefer deterministic, reviewable steps over vague advice or tool-specific magic.
+- Every AI interaction must leave the user holding something useful ("never leave empty-handed")
+- All AI error-recovery procedures must be visible on screen, not hidden in documentation
+- Manual fallback paths must exist for every AI-assisted workflow
+- Confidence levels must be communicated when AI output accuracy varies
 
 ## Anti-Patterns
 
-- Treating examples as copy-paste truth without checking fit, constraints, or failure modes.
-- Loading every reference file by default instead of using progressive disclosure.
+- Replacing an expert directly — AI should assist and augment, never compete
+- Chat-only information architecture — chat is a command line, not a complete product
+- Copying ChatGPT patterns blindly — invent patterns suited to your specific use case
+- Optimising on accuracy metrics alone — real-world ROI is the metric that matters
+- Large overlay copilot panels that obscure parent content — use side panels instead
 
 ## Outputs
 
-- A concrete result that fits the task: implementation guidance, review findings, architecture decisions, templates, or generated artifacts.
-- Clear assumptions, tradeoffs, or unresolved gaps when the task cannot be completed from available context alone.
-- References used, companion skills, or follow-up actions when they materially improve execution.
+- AI surface design specification with trust/transparency patterns applied
+- Error state and graceful degradation design for AI failure modes
+- Human oversight control placement (start, stop, pause, approve)
 
 ## Evidence Produced
 


### PR DESCRIPTION
Hey @peterbamuhigire 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| update-claude-documentation | 16% | 67% | +51% |
| ux-for-ai | 34% | 62% | +28% |
| new-project | 35% | 67% | +32% |
| software-business-models | 37% | 68% | +31% |
| language-standards | 40% | 74% | +34% |

This PR covers your 5 lowest-scoring skill(s) in the repo (out of 237 total). The remaining skills can be improved incrementally via the included GitHub Action — every future PR that touches a `SKILL.md` will get automatic review scores.

<details>
<summary>What changed in update-claude-documentation</summary>

- **Fixed reserved word violation** — renamed `name` field from `update-claude-documentation` to `update-project-documentation` (the word "claude" is reserved by tessl validators and was causing the skill to fail deterministic validation at 16%)
- **Description rewritten** with concrete "Use when..." clause covering session-end documentation, code changes, and architecture updates
- **Added `user-invocable: true`** and **`triggers`** array (`update docs`, `close for the day`, `sync documentation`, etc.)
- **Replaced generic boilerplate** Use When/Do Not Use When/Workflow/Quality Standards with skill-specific guidance tailored to the documentation update workflow

</details>

<details>
<summary>What changed in ux-for-ai</summary>

- **Description rewritten** with explicit "Use when..." clause and RETCH framework mention for discoverability
- **Added `user-invocable: true`** and **`triggers`** array (`AI UX review`, `chatbot UX`, `copilot design`, etc.)
- **Replaced generic sections** with AI-specific Use When (chatbots, copilots, search, recommendations), Do Not Use When (no AI component, backend-only), and concrete Required Inputs
- **Anti-patterns section** now lists the 5 most critical AI UX anti-patterns from the skill body for quick reference

</details>

<details>
<summary>What changed in new-project</summary>

- **Description rewritten** from vague "Use when the task matches skill" to concrete explanation of the 4-question interview, PRIME methodology, and auto domain deduction
- **Added `user-invocable: true`** and **`triggers`** array matching the existing trigger phrases in the skill body (`start a new project`, `scaffold a project`, etc.)
- **Added `portable: true`** and `compatible_with` metadata for consistency with other skills
- **Removed redundant metadata block** that duplicated frontmatter keys as nested strings

</details>

<details>
<summary>What changed in software-business-models</summary>

- **Description rewritten** with "Use when..." clause covering business model selection, services-to-product transition, and Cusumano's frameworks
- **Added `user-invocable: true`** and **`triggers`** array (`product vs service`, `SaaS business model`, `open source strategy`, etc.)
- **Replaced generic sections** with domain-specific Use When (5 concrete scenarios), Do Not Use When (with cross-references to related skills), and actionable Required Inputs
- **Workflow now references specific skill sections** (1-7) with clear step sequence

</details>

<details>
<summary>What changed in language-standards</summary>

- **Description rewritten** with "Use when..." clause covering the three supported languages and specific content types
- **Added `user-invocable: true`** and **`triggers`** array (`British English style`, `East African English`, `multilingual copy`, etc.)
- **Replaced generic sections** with content-specific Use When/Do Not Use When scenarios and concrete Required Inputs (target language, content type, audience)
- **Quality Standards** now list the 5 most important language rules for quick reference

</details>

## Tessl Skill Review GitHub Action ✅

I've also included a GitHub Action (`.github/workflows/skill-review.yml`) that automatically reviews any `SKILL.md` changed in future PRs and posts scores as a PR comment.

**What this gives you:**
- 🔍 Automatic `tessl skill review` runs on every PR touching `SKILL.md`
- 💬 One updated PR comment with scores and improvement feedback
- 🔓 **Zero extra accounts** — contributors don't need a Tessl login; only `GITHUB_TOKEN` is used
- ✅ **Non-blocking by default** — feedback-only, no surprise red CI (add `fail-threshold: 70` later if you want a hard gate)
- 📈 Covers future skills incrementally as contributors edit them

## Want automatic AI optimization on every SKILL.md change? 🚀

The action I've added gives you **review scores** on PRs. We also have a more powerful variant — [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize) — that can:

- Run **AI-powered optimization suggestions** on every `SKILL.md` PR (requires adding `TESSL_API_TOKEN` as a repo secret)
- Let contributors accept suggested improvements by commenting **`/apply-optimize`**
- Still works in review-only mode with zero secrets

Interested? Tick the box and I'll raise a follow-up PR:

- [ ] **Yes please!** Add the `tesslio/skill-review-and-optimize` action so every SKILL.md PR gets AI optimization suggestions + the `/apply-optimize` flow
- [ ] **No thanks** — the review scores action is enough for now

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch — just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me — [@rohan-tessl](https://github.com/rohan-tessl) — if you hit any snags.

Thanks in advance 🙏
